### PR TITLE
ApnSettings : Ensure default apn dialog isn't shown twice

### DIFF
--- a/src/com/android/settings/ApnSettings.java
+++ b/src/com/android/settings/ApnSettings.java
@@ -107,6 +107,7 @@ public class ApnSettings extends SettingsPreferenceFragment implements
             "persist.radio.use_nv_for_ehrpd", false);
 
     private IntentFilter mMobileStateFilter;
+    private ProgressDialog mDialog;
 
     private boolean mUnavailable;
 
@@ -120,7 +121,7 @@ public class ApnSettings extends SettingsPreferenceFragment implements
                 case CONNECTED:
                     if (!mRestoreDefaultApnMode) {
                         fillList();
-                    } else {
+                    } else if (mDialog == null || !mDialog.isShowing()) {
                         showDialog(DIALOG_RESTORE_DEFAULTAPN);
                     }
                     break;
@@ -537,12 +538,21 @@ public class ApnSettings extends SettingsPreferenceFragment implements
     }
 
     @Override
+    public void removeDialog(int id) {
+        super.removeDialog(id);
+        mDialog = null;
+    }
+
+    @Override
     public Dialog onCreateDialog(int id) {
         if (id == DIALOG_RESTORE_DEFAULTAPN) {
-            ProgressDialog dialog = new ProgressDialog(getActivity());
-            dialog.setMessage(getResources().getString(R.string.restore_default_apn));
-            dialog.setCancelable(false);
-            return dialog;
+            if (mDialog != null) {
+                mDialog.dismiss();
+            }
+            mDialog = new ProgressDialog(getActivity());
+            mDialog.setMessage(getResources().getString(R.string.restore_default_apn));
+            mDialog.setCancelable(false);
+            return mDialog;
         }
         return null;
     }


### PR DESCRIPTION
There can be cases where while a device is restoring default apns,
ACTION_ANY_DATA_CONNECTION_STATE_CHANGED is broadcasted and mobileDataState
becomes CONNECTED. Current logic is to throw up another dialog blindly in a
case where this broadcast is received and we are in the middle of restoring.
This can result in multiple dialogs and losing reference to the first dialog,
hence not being able to dismiss it.

Resolve this by keeping a reference to the dialogs, and ensuring one
isn't showing before throwing another one.

issue-id: CYNGNOS-882

Change-Id: I9e93f2a165ba40d36c85976960a5b5a19a3815d3