### PR TITLE
Settings: regulatory: Wrap the layout in a ScrollView

### DIFF
--- a/res/layout/regulatory_info.xml
+++ b/res/layout/regulatory_info.xml
@@ -13,33 +13,38 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
-    <TextView
-        android:id="@+id/sarValues"
-        android:textColor="@color/regulatory_text_color"
-        android:textSize="14sp"
-        android:padding="5dp"
-        android:layout_width="wrap_content"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"/>
-    <TextView
-        android:id="@+id/icCodes"
-        android:textColor="@color/regulatory_text_color"
-        android:textSize="14sp"
-        android:padding="5dp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"/>
-    <ImageView
-        android:id="@+id/regulatoryInfo"
-        android:adjustViewBounds="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:scaleType="centerCrop"
-        android:src="@drawable/regulatory_info"
-        android:visibility="gone"/>
-</LinearLayout>
+        android:orientation="vertical"
+        >
+        <TextView
+            android:id="@+id/sarValues"
+            android:textColor="@color/regulatory_text_color"
+            android:textSize="14sp"
+            android:padding="5dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"/>
+        <TextView
+            android:id="@+id/icCodes"
+            android:textColor="@color/regulatory_text_color"
+            android:textSize="14sp"
+            android:padding="5dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"/>
+        <ImageView
+            android:id="@+id/regulatoryInfo"
+            android:adjustViewBounds="true"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scaleType="centerCrop"
+            android:src="@drawable/regulatory_info"
+            android:visibility="gone"/>
+    </LinearLayout>
+</ScrollView>
 


### PR DESCRIPTION
This screen allows an optional image to be provided via overlay,
this image might be bigger than the screen height, and usually is
when the phone is in landscape. This cuts the image and only
shows what the screen allows.

This patch wraps it in a ScrollView to ensure that the user can
read the whole image.

Additionally, it changes the ImageView width to take the full width
of the parent, making centerCrop work as expected and centering the
image.

Change-Id: Ie8433767fe333cb4b019608208a45cd0a653641b
Ticket: HAM-138